### PR TITLE
Base form styles

### DIFF
--- a/sass/partials/_base.scss
+++ b/sass/partials/_base.scss
@@ -51,9 +51,6 @@ th, td {
   padding: 0.5em;
 }
 
-// Forms 
-
-
 /*
  * Rules for base drupal elements
  */

--- a/sass/partials/components/forms/_forms.scss
+++ b/sass/partials/components/forms/_forms.scss
@@ -1,0 +1,85 @@
+//
+// Global forms
+//
+
+label,
+.webform-container-inline label {
+  @include font-size(14);
+  font-weight: bold;
+  color: #333;
+  display: block;
+  margin-bottom: 8px;
+}
+
+label.option {
+  display: inline;
+  font-weight: 400;
+  margin-left: 0.5em;
+}
+
+select {
+  @include font-size(12);
+  width: 100%;
+}
+
+input[type="text"],
+input[type="email"],
+input[type="password"],
+textarea {
+  @include font-size(12);
+  border-radius: 3px;
+  border: solid #e1e1e1 1px;
+  background: #fff;
+  margin-bottom: 5px;
+  padding: 5px;
+}
+input[type="text"],
+input[type="email"],
+input[type="password"] {
+  width: 100%;
+  @include media(min-width 767) {
+    max-width: 300px;
+  }
+}
+input[type="checkbox"],
+input[type="radio"] {
+  @include font-size(16);
+  vertical-align: baseline;
+}
+input[type="submit"] {
+  border: 0;
+  outline: 0;
+  padding: 8px 25px;
+  width: 100%;
+  margin-bottom: 10px;
+  @include media(min-width 767) {
+    width: auto;
+    display: inline-block;
+    margin-right: 10px;
+    margin-bottom: 0;
+  }
+     -moz-transition: all 0.2s ease-in-out;
+  -webkit-transition: all 0.2s ease-in-out;
+          transition: all 0.2s ease-in-out;
+}
+.form-type-radio {
+  margin-bottom: 5px;
+}
+
+// Formatting options
+
+.field-widget-text-textarea .form-type-textarea {
+  margin-bottom: 10px;
+}
+.filter-wrapper {
+  border: 0;
+  background: #fff;
+  border-radius: 5px;
+}
+
+// Errors
+.form-item input.error,
+.form-item textarea.error,
+.form-item select.error {
+  border: 2px solid red;
+}

--- a/sass/partials/components/forms/_webforms.scss
+++ b/sass/partials/components/forms/_webforms.scss
@@ -1,0 +1,7 @@
+//
+// Global webforms
+//
+
+.webform-component {
+  margin-bottom: 15px;
+}

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -17,5 +17,7 @@
 @import "partials/placeholders";
 @import "partials/base";
 @import "partials/layout";
+@import "partials/components/forms/forms";
+@import "partials/components/forms/webforms";
 
 // @import ...


### PR DESCRIPTION
I added base forms styles for the theme:
1. Removed forms comment from base partial
2. Added components folder to style.scss
3. Added components folder with forms base and webforms base, the latter almost empty.

I added media queries to the forms base styles, based on experience from past themes. They should be changed to the breakpoint variables that will be added soon. 
