### PR TITLE
Added variables for breakpoints

### DIFF
--- a/sass/partials/_variables.scss
+++ b/sass/partials/_variables.scss
@@ -13,3 +13,6 @@ $max-width: 1200px;
 $grid-colums: 13;
 
 // Breakpoints
+$desktop: 1000px;
+$tablet: 700px;
+$mobile-large: 500px;


### PR DESCRIPTION
Added breakpoint variables to create a discussion:

First, we have treated tablet devices (or at least the larger ones, 700px +) as desktop machines when we think about navigation, thus I have added a breakpoint for tablet devices as min-width: 700px. 

This can be changed per theme of course, but from our experience and the ability to bootstrap from this theme, everything from 700px and up would have a full nav, and that width will trigger the transformation from "toggle to full nav".

Secondly, I have added a variable called $mobile-large. This in order to have a semantic name for what it is: everything below 500px is a "mobile". Larger mobile phones requiere repositioning of images when in landscape mode for e.g. lists (again, "experience bias" talking here) so we always find ourselves having a need for this variable.

Third: should we add a $mobile-only and $desktop-only variables as well? I know I have had the need in the past, although, Im curious about what you guys think about adding them as a base (my inclination is "NO").
